### PR TITLE
Addresses #59 and #69

### DIFF
--- a/bot/handlers/notify_groups/invitations.py
+++ b/bot/handlers/notify_groups/invitations.py
@@ -301,8 +301,8 @@ def reply_to_invite(update, context):
         notify_group_invitation["mgr_msg"].edit_text(
             f"{creator_mention} The invited users have successfully responded "
             "to the invite so you can no longer revoke the invitation\. You "
-            f"can however enter `/modify_notify_group {notify_group['name']}` "
-            "to remove any members from your notify group",
+            f"can however use the `/modify_notify_group command in this group "
+            "chat to remove any members from your notify group",
             parse_mode=ParseMode.MARKDOWN_V2
         )
         notify_group_invitation["inv_msg"].edit_text(

--- a/bot/handlers/status/add_status_user.py
+++ b/bot/handlers/status/add_status_user.py
@@ -354,12 +354,15 @@ def process_psn_online_id(update, context):
     del context.user_data["messages_to_delete"]
 
     if context.user_data.get("group_name"):
-        mention = (f"[{username}](tg://user?id="
-                   f"{context.user_data.get('user_id')})")
+        mention = get_one_mention(
+            context.bot,
+            context.user_data['user_id'],
+            context.user_data["chat_id"]
+        )
         context.bot.send_message(
             context.user_data.get("chat_id"),
-            f"`{context.user_data.get('display_name')}` has been added to the "
-            f"/status command by {mention}",
+            f"`{context.user_data['status_user']['display_name']}` has been "
+            f"added to the /status command by {mention}",
             parse_mode=ParseMode.MARKDOWN_V2
         )
 

--- a/bot/handlers/status/common.py
+++ b/bot/handlers/status/common.py
@@ -12,7 +12,7 @@ def stringify_status_user(bot: Bot, status_user: dict):
         bot, status_user["user_id"], status_user["chat_id"]
     )
     creator_details = (
-        f"{creator_mention} in the {status_user['group_name']}"
+        f"{creator_mention} in the `{status_user['group_name']}` group chat"
         if status_user.get('group_name')
         else f"{creator_mention} in this private chat"
     )

--- a/bot/handlers/status/modify_status_user.py
+++ b/bot/handlers/status/modify_status_user.py
@@ -780,9 +780,10 @@ def confirm_delete(update, context):
         )
 
     if group_name != None:
-        user_username = update.from_user['username']
-        mention = (
-            f"[{user_username}](tg://user?id={context.user_data['user_id']})"
+        mention = get_one_mention(
+            context.bot,
+            context.user_data["user_id"],
+            context.user_data["chat_id"]
         )
         context.bot.send_message(
             context.user_data["chat_id"],


### PR DESCRIPTION
This commit addresses the issues listed above. Specifically:

- Variable name is fixed (refraction wasn't done fully) so that
status's user's display name is accessed
- Remove all old mention styles and use the implemented function
to get mentions (refraction wasn't done fully)
- Fix command usage description in invitations for a notify group