### PR TITLE
Address #70

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Created a CHANGELOG.md
 - Add a Semantic Version to keep track of bot version
+- The bot will now remove /notify command messages from the group chat if the
+bot has permissions to delete messages
 
 ### Changed
 - Change command ordering of Dockerfile to promote faster

--- a/bot/handlers/notify_groups/utilities.py
+++ b/bot/handlers/notify_groups/utilities.py
@@ -1,4 +1,5 @@
 from telegram import ParseMode
+from telegram.error import BadRequest
 from telegram.utils.helpers import escape_markdown
 from general.db import DBConnection
 from handlers.common import get_one_mention, send_loud_and_silent_message
@@ -87,6 +88,13 @@ def notify(update, context):
     else:
         notify_msg += f"\n\n{curr_user_mention} wants your attention"
 
+    # Delete the user's "/notify" message
+    try:
+        update.message.delete()
+    except BadRequest:
+        # This means that our bot doesn't have the appropriate permissions to
+        # delete a message in the group chat so we can just silently fail
+        pass
 
     # Send the notify message, tagging all the notify group members
     update.message.reply_text(


### PR DESCRIPTION
This commit adds the ability for the bot to delete the /notify
command from the creator of the notify group if the bot has
sufficient permissions to delete messages in a group chat.
If it doesn't it just silently fails