### PR TITLE
Addresses #77

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add a Semantic Version to keep track of bot version
 - The bot will now remove /notify command messages from the group chat if the
 bot has permissions to delete messages
+- More user feedback and engagement from the bot in the invitation to notify
+group flow
 
 ### Changed
 - Change command ordering of Dockerfile to promote faster
@@ -27,7 +29,7 @@ creation and modification of a status user
 - Fixed bad command usage that was serving as a help for the user for
 the /modify_notify_group command in the invite to notify group flow
 - Improve user prompt when there are no status users to disply the status of
-
+- Allow multiple invites to a notify group
 ### Removed
 
 

--- a/bot/bot.py
+++ b/bot/bot.py
@@ -389,11 +389,11 @@ def register_conversation_commands(dispatcher):
             handlers.notify_groups.invitations.WAITING_FOR_REPLY: [
                 CallbackQueryHandler(
                     handlers.notify_groups.invitations.reply_to_invite,
-                    pattern="^(accept|decline)_[0-9a-f]{24}$"
+                    pattern="^(accept|decline)_[0-9a-f]{24}_[0-9a-f]{24}$"
                 ),
                 CallbackQueryHandler(
                     handlers.notify_groups.invitations.revoke_invitation,
-                    pattern="^revoke-invite_[0-9a-f]{24}$"
+                    pattern="^revoke-invite_[0-9a-f]{24}_[0-9a-f]{24}$"
                 ),
             ]
         },

--- a/bot/handlers/notify_groups/creation.py
+++ b/bot/handlers/notify_groups/creation.py
@@ -10,8 +10,6 @@ from telegram.error import Unauthorized
 # Conversation states for the CommandHandler for add_status_user
 TYPING_NAME, TYPING_DESCRIPTION = range(2)
 
-# TODO (Issue #31): Prevent Notify Groups from having a group name that includes a space
-
 
 def start(update, context):
     """


### PR DESCRIPTION
This commit allows multiple invites to a notify groups instead of
just one. This commit also:

- Removes mentions of Issue #31 and completes an incomplete
refraction
- Adds more user prompts to give the user more feedback on button
clicks.

However, the invite_to_notify_group handlers still need a fair bit
more work and issues to improve the feature