### PR TITLE
Address #74

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add further instructions for user when they start the bot after they were
 unable to run a command before because the bot was blocked/not started
+- Add the ability to list specific notify groups if they are provided as
+command arguments to the /list_notify_groups command.
 ### Changed
 - Fixes the v0.1.0 link for CHANGELOG.md
 ### Removed


### PR DESCRIPTION
This commit allows the user to list
specific notify groups instead of
listing all the notify groups in a group
chat. However, this does NOT add
this information to the help command.
We will add that later.