### PR TITLE
Addresses #76

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 unable to run a command before because the bot was blocked/not started
 - Add the ability to list specific notify groups if they are provided as
 command arguments to the /list_notify_groups command.
+- List notify groups alphabetically when notify groups are listed using the
+/list_notify_groups command.
 ### Changed
 - Fixes the v0.1.0 link for CHANGELOG.md
 ### Removed

--- a/bot/handlers/notify_groups/utilities.py
+++ b/bot/handlers/notify_groups/utilities.py
@@ -139,10 +139,10 @@ def list_notify_groups(update, context):
     else:
         # Get all the notify groups connected to this group chat if there are
         # no context arguments
-        notify_groups = DBConnection().find(
+        notify_groups = sorted(DBConnection().find(
             "notifygroups",
             {"chat_id": chat_id}
-        )
+        ), key=lambda notify_group: notify_group["name"])
 
     # Send an error message if no notify groups exist.
     if not notify_groups:
@@ -166,7 +166,8 @@ def list_notify_groups(update, context):
         # returning them all the notify groups found connected to this group
         # chat
         msg = (
-            "Listed below are all the notify groups for this group chat:\n\n"
+            "Listed below are all the notify groups for this group chat "
+            "(sorted alphabetically):\n\n"
         )
     # msg += "`\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-`\n"
     for notify_group in notify_groups:


### PR DESCRIPTION
This commit sorts the notify groups
alphabetically if no notify groups are
specified. It also adds the hint that
the notify groups are sorted to the
message from the bot