### PR TITLE
Addresses #76

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ command arguments to the /list_notify_groups command.
 /list_notify_groups command.
 ### Changed
 - Fixes the v0.1.0 link for CHANGELOG.md
+- Instead of setting the notify group names as pre-formatted, the bot will bold
+them when a notify group is to be stringized.
 ### Removed
 
 

--- a/bot/handlers/notify_groups/common.py
+++ b/bot/handlers/notify_groups/common.py
@@ -55,7 +55,7 @@ def stringify_notify_group(bot: Bot, notify_group: dict):
         invited_str = "`None`"
 
     return (
-        f"`{notify_group_name}` _\(Created by {creator_mention}\)_\n"
+        f"*{notify_group_name}* _\(Created by {creator_mention}\)_\n"
         "__Group Description__\n"
         f"`{notify_group_description}`\n"
         "__Current Members__\n"

--- a/bot/handlers/notify_groups/utilities.py
+++ b/bot/handlers/notify_groups/utilities.py
@@ -167,7 +167,7 @@ def list_notify_groups(update, context):
         # chat
         msg = (
             "Listed below are all the notify groups for this group chat "
-            "(sorted alphabetically):\n\n"
+            "\(sorted alphabetically\):\n\n"
         )
     # msg += "`\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-`\n"
     for notify_group in notify_groups:


### PR DESCRIPTION
This commit addresses the issue of
bolding the title of notify groups when
they are listed. These bold titles are
to replace the pre-formatted titles.